### PR TITLE
Clean parse_ast

### DIFF
--- a/src/compile_automaton.ml
+++ b/src/compile_automaton.ml
@@ -17,7 +17,7 @@ let mk_fby_merge init var over t eqs loc =
   let fby = {pexpr_desc = fby; pexpr_loc = loc } in
   PE_eq ({peq_patt = var; peq_expr = fby})
 
-let mk_constr_expr name loc = { pexpr_desc = PE_constr name; pexpr_loc = loc }
+let mk_constr_expr t name loc = { pexpr_desc = PE_const (Asttypes.Cadt (t, Some name)); pexpr_loc = loc }
 
 let trad {pautom_loc; pautom} =
   let constrs = List.map (function
@@ -48,8 +48,8 @@ let trad {pautom_loc; pautom} =
   let (cond_locals, vars), eqs_state =
     List.fold_left_map
     (fun (cond_loc_acc, vars_acc) {pn_cond; pn_out; pn_case={pn_constr; pn_loc; _}} ->
-      let c1 = mk_constr_expr pn_out pautom_loc in
-      let c2 = mk_constr_expr pn_constr pautom_loc in
+      let c1 = mk_constr_expr t.name pn_out pautom_loc in
+      let c2 = mk_constr_expr t.name pn_constr pautom_loc in
       let name = gen "cond" in
       let var_cond = { pexpr_desc = PE_ident name; pexpr_loc = pn_loc} in
       let peq_patt =

--- a/src/parse_ast.ml
+++ b/src/parse_ast.ml
@@ -18,7 +18,6 @@ and p_expr_desc =
   | PE_tuple of p_expr list
   | PE_merge of p_expr * (bool * p_expr) * (bool * p_expr)
   | PE_merge_adt of p_expr * (string * p_expr) list
-  | PE_constr of string
 
 type p_patt =
   { ppatt_desc: p_patt_desc;

--- a/src/parsed_ast_printer.ml
+++ b/src/parsed_ast_printer.ml
@@ -7,7 +7,6 @@ open Print_base
 
 let rec print_exp fmt e = match e.pexpr_desc with
   | PE_const c -> print_const fmt c
-  | PE_constr x
   | PE_ident x -> fprintf fmt "%s" x
   | PE_op (op, el) -> fprintf fmt "%a(%a)" print_op op print_arg_list el
   | PE_app (name, e_list) ->

--- a/src/typing.ml
+++ b/src/typing.ml
@@ -206,12 +206,6 @@ let rec type_expr env e =
   { texpr_desc = desc; texpr_type = t; texpr_loc = e.pexpr_loc; }
 
 and type_expr_desc env loc = function
-  | PE_constr c ->
-      let pt = match List.find_opt (fun {constr; _} -> List.mem c constr) env.types with
-        | None -> assert false
-        | Some e -> e in
-      TE_const (Cadt (pt.name, Some c)), [Tadt pt.name]
-
   | PE_const c ->
     TE_const c , type_constant c
 


### PR DESCRIPTION
Remove from parse_ast the expression `PE_constr` and use `PE_const (Cadt ...)` instead in the automaton translation